### PR TITLE
Some improvements on Mochi & Tamago

### DIFF
--- a/mochi_filter.txt
+++ b/mochi_filter.txt
@@ -41,19 +41,19 @@ hs-exp.jp##.dfad
 
 !Youtube
 !一旦全面見直した。2017.10.31
-||www.youtube.com/yts/jsbin/www-pagead-id-
+||youtube.com/yts/jsbin/www-pagead-id-
 !||googleads.g.doubleclick.net^
 ||youtube.com/get_midroll_
 ||pagead2.googlesyndication.com^
 youtube.com##.ad-container
 youtube.com##.video-ads
 youtube.com##.ytp-ad-progress-list
-||www.google.co.jp/pagead/lvz?
+||google.co.jp/pagead/lvz?
 !||static.doubleclick.net/instream/ad_status.js
 youtube.com###player-ads
 !||pubads.g.doubleclick.net^
 ||youtube.com/pagead/
-||www.youtube.com/ads/$image
+||youtube.com/ads/$image
 !||securepubads.g.doubleclick.net
 =adunit&$domain=youtube.com
 !Peter Lowe’s Ad and tracking server listで一括ブロックされている
@@ -100,7 +100,7 @@ www.google.co.jp,www.google.com###bottomads
 !下に書いてある
 !||google.co.jp/gen_204?$other
 !google.co.jp,www.google.com##.commercial-unit-desktop-rhs
-||www.google.com/ads/
+||google.com/ads/
 ||google.co.jp/gen_204?$other
 ||google.com/gen_204?$other
 !下記で画像の遷移が動作しない
@@ -739,7 +739,7 @@ outlook.live.com##:xpath(//div[contains(@class, 'fbAdLink')]/parent::div/parent:
 ||ad.auditude.com/adserver/
 ||metrics.brightcove.com/tracker?
 !||static.doubleclick.net/instream/ad_status.js
-||www.youtube.com/ad_data_
+||youtube.com/ad_data_
 !||doubleclick.net/gampad/ads?
 !END-------------------------------------------------
 gyao.yahoo.co.jp##.adPV
@@ -1121,7 +1121,7 @@ kakakumag.com##.fixedRightAdContainer
 ! 楽天トラッカー
 !/akam/11/*
 !楽天以外のサイトもいろいろあるので汎用化2019.9.27
-!||www.rakuten.co.jp/akam/11/
+!||rakuten.co.jp/akam/11/
 ^akam^11^
 ||r.r10s.jp/com/js/omniture/plugin/sc_trackingid.js|
 ||ias.rakuten.co.jp/gw.js?$subdocument
@@ -1142,18 +1142,18 @@ rakuten.co.jp###footer-floating-bnr
 
 !ublockで尼の-22アフィリンク踏んだ時に厳格なブロックの警告出してほしいんだけどどう設定すればいい？
 !https://egg.5ch.net/test/read.cgi/software/1556498678/616
-!||www.amazon.co.jp/exec/obidos/ASIN/*/*-22/*$document,1p
+!||amazon.co.jp/exec/obidos/ASIN/*/*-22/*$document,1p
 
 
 
 !ファミ通
-||www.famitsu.com/ad/
+||famitsu.com/ad/
 !Youtube埋め込み動画までブロックされてしまう
 !www.famitsu.com##iframe
 www.famitsu.com###adTop
 ||ssl.webtracker.jp/ad/
 www.famitsu.com##.ad-header-video
-||www.famitsu.com/js/1411/ad.js
+||famitsu.com/js/1411/ad.
 www.famitsu.com##.adArticleBottomWrap
 www.famitsu.com##.adTc
 ||ssl.webtracker.jp
@@ -1172,15 +1172,15 @@ dengekionline.com###rectangleBanner
 watch.impress.co.jp##.ad.billboard
 
 !weblio 一旦見直し2019.10月
-||www.googletagservices.com/tag/js/gpt.js$domain=weblio.jp
+||googletagservices.com/tag/js/gpt.js$domain=weblio.jp
 ||cloudfront.net/recentposts?$domain=weblio.jp
 ||yjtag.jp/tag.js$domain=weblio.jp
 ||connect.facebook.net^$domain=weblio.jp
-||www.googleadservices.com/pagead/
-||www.google-analytics.com^$domain=weblio.jp
+||googleadservices.com/pagead/
+||google-analytics.com^$domain=weblio.jp
 weblio.jp##.flex-rectangle-ads-frame
 weblio.jp##.premium-service-button
-||www.facebook.com/plugins/like.php?$domain=weblio.jp
+||facebook.com/plugins/like.php?$domain=weblio.jp
 ||platform.twitter.com^$domain=weblio.jp
 ||googlesyndication.com/pagead/
 ||weblio.hs.llnwd.net/e7/img/ad/
@@ -1196,7 +1196,7 @@ eow.alc.co.jp###AreaHeaderRight
 eow.alc.co.jp###AreaUpperLeftInner > p
 eow.alc.co.jp##.pr_text
 eow.alc.co.jp##.mb_0
-||www.google.com/ads/
+||google.com/ads/
 ||ds.advg.jp^
 eow.alc.co.jp###introduceEowp
 ||eow.alc.co.jp/content/img/btn_eijiro_pro.gif$image
@@ -1208,7 +1208,7 @@ news.goo.ne.jp##.NR-pr
 news.goo.ne.jp##div[id^="gooad-"]
 ||adcdn.goo.ne.jp^
 ||l.logly.co.jp/lift_widget.js?adspot_id=
-||www.google.com/adsense/search/ads.js
+||google.com/adsense/search/ads.
 oshiete.goo.ne.jp##.pr-unit
 oshiete.goo.ne.jp###gooad-long
 oshiete.goo.ne.jp###gheader
@@ -1234,9 +1234,9 @@ myjitsu.jp##article[id^="related-post-ad"]
 ||rubiconproject.com^
 
 !ZAKZAK
-||www.zakzak.co.jp/common/js/popin/loadPopIn.js
+||zakzak.co.jp/common/js/popin/loadPopIn.
 !ビーコン
-||b.ranking.apis.sankei-digital.co.jp/zak/ranking/img/beacon.gif
+||b.ranking.apis.sankei-digital.co.jp/zak/ranking/img/beacon.
 
 
 !日経新聞
@@ -1247,7 +1247,7 @@ myjitsu.jp##article[id^="related-post-ad"]
 ||bizad.nikkeibp.co.jp/NBP_AD/itpro/parts/itp_welcome_schedule.js?
 ! 日経BPトラッカー
 !/js/bpcommon/onetag/bpTrackVars$script
-!||www.nikkeibp.co.jp/js/bpcommon/onetag/bpTrackVars$script
+!||nikkeibp.co.jp/js/bpcommon/onetag/bpTrackVars$script
 /js/bpcommon/onetag/bpTrackVars$script
 
 !-----------------------------------------------------------------------
@@ -1269,18 +1269,18 @@ myjitsu.jp##article[id^="related-post-ad"]
 !-----------------------------------------------------------------------
 
 !産経
-||www.sankei.com/apr_news/js/others/adGpt.js
-||www.sankei.com/apr_west/js/others/adEx_display1.js
-||www.sankei.com/apr_west/js/others/adsense_m3.js
-||www.sankei.com/apr_west/css/v1/common/ad.css
+||sankei.com/apr_news/js/others/adGpt.
+||sankei.com/apr_west/js/others/adEx_display1.
+||sankei.com/apr_west/js/others/adsense_m3.
+||sankei.com/apr_west/css/v1/common/ad.
 ||sankei2ad.durasite.net^
 !記事の右上の広告
 www.sankei.com###adToprectangle
 !popin（モバイル広告）
-||www.sankei.com/apr_common/js/others/popin.js
+||sankei.com/apr_common/js/others/popin.
 !広告
-||www.sankei.com/apr_news/js/others/adEx_display1.js
-||www.sankei.com/apr_news/js/others/adsense_m3.js
+||sankei.com/apr_news/js/others/adEx_display1.
+||sankei.com/apr_news/js/others/adsense_m3.
 www.sankei.com##div[style="width:300px;height:600px;"]
 www.sankei.com##.module_ad
 www.sankei.com##.module secondary
@@ -1303,8 +1303,8 @@ toyokeizai.net###adexchange
 !朝日
 www.asahi.com##.AdMod
 ||ad.yieldlab.net^
-||www.asahi.com/ad/
-||www.asahicom.jp/ad/
+||asahi.com/ad/
+||asahicom.jp/ad/
 www.asahi.com##.Pr
 www.asahi.com##.OutbrainAdMod
 www.asahi.com##.PrTextMod
@@ -1313,29 +1313,29 @@ www.asahi.com##.AdArea
 www.asahi.com###HometopAdOuter
 !Chromeで朝日新聞の記事を開くとBraveブラウザの広告が出る
 !http://egg.5ch.net/test/read.cgi/software/1585819901/367
-||www.asahi.com/brave/modal-dist/index.js
+||asahi.com/brave/modal-dist/index.js
 
 !読売
-!||www.yomiuri.co.jp/cont2/ad/js/ad_world.js
+!||yomiuri.co.jp/cont2/ad/js/ad_world.
 ||impact-ad.jp^
 ||adserver.adtechjp.com^
-||www.yomiuri.co.jp/cont2/ad/
+||yomiuri.co.jp/cont2/ad/
 !文字列選択したときのポップアップ？
 !http://www.afpbb.com/であわせて読みたいが消えてしまう
 !||api.popin.cc^
-!||www.yomiuri.co.jp/cont2/ad/js/ad_home.js
-||www.yomiuri.co.jp/adv/
-!||www.yomiuri.co.jp/cont2/ad/
+!||yomiuri.co.jp/cont2/ad/js/ad_home.
+||yomiuri.co.jp/adv/
+!||yomiuri.co.jp/cont2/ad/
 www.yomiuri.co.jp##.subhead
 !||smrtpxl.advertising.com^
 !gif動画がちらついてうざい
-!||www.yomiuri.co.jp/cont2/g2/m_pr_chuo.gif
-!||www.yomiuri.co.jp/cont2/g2/m_pr_gakushuin.gif
+!||yomiuri.co.jp/cont2/g2/m_pr_chuo.
+!||yomiuri.co.jp/cont2/g2/m_pr_gakushuin.
 !www.yomiuri.co.jp##a[href^="http://www.yomiuri.co.jp/adv/"]
-!||www.yomiuri.co.jp/cont2/g2/m_pr_waseda.gif
-!||www.yomiuri.co.jp/cont2/g2/m_pr_sophia.gif
-!||www.yomiuri.co.jp/cont2/g2/m_pr_hosei.gif
-||www.yomiuri.co.jp/cont2/g2/m_pr_
+!||yomiuri.co.jp/cont2/g2/m_pr_waseda.
+!||yomiuri.co.jp/cont2/g2/m_pr_sophia.
+!||yomiuri.co.jp/cont2/g2/m_pr_hosei.
+||yomiuri.co.jp/cont2/g2/m_pr_
 !読売、下から出てくるフッター
 www.yomiuri.co.jp##.layout-footer
 www.yomiuri.co.jp###ad_dfp_premiumrec
@@ -1354,31 +1354,31 @@ www.yomiuri.co.jp###ad_dfp_premiumrec
 !||bunshun.jp/oo/bs/m.gif?
 !||gendai.ismedia.jp/oo/im/m.gif?
 !||diamond.jp/oo/d/m.gif?
-!||www.dhbr.net/oo/d/m.gif?
+!||dhbr.net/oo/d/m.gif?
 !! メディア系ビーコン追加
 !||mikiki.tokyo.jp/oo/mk/m.gif?
 !||toyokeizai.net/oo/tk/m.gif?
 !||ure.pia.co.jp/oo/pia/m.gif?
-!||www.afpbb.com/oo/afp/m.gif?
-!||www.fsight.jp/oo/other/m.gif?
-!||www.jprime.jp/oo/other/m.gif?
+!||afpbb.com/oo/afp/m.gif?
+!||fsight.jp/oo/other/m.gif?
+!||jprime.jp/oo/other/m.gif?
 ||bunshun.jp/oo/
 ||gendai.ismedia.jp/oo/
 ||diamond.jp/oo/
-||www.dhbr.net/oo/
+||dhbr.net/oo/
 !! メディア系ビーコン追加
 ||mikiki.tokyo.jp/oo/
 ||toyokeizai.net/oo/
 ||ure.pia.co.jp/oo/
-||www.afpbb.com/oo/
-||www.fsight.jp/oo/
-||www.jprime.jp/oo/
+||afpbb.com/oo/
+||fsight.jp/oo/
+||jprime.jp/oo/
 
 
 !日テレNews24
 !http://www.ntv.co.jp/fcwc/index.htmlが見れない
-!||www.ntv.co.jp/ad-navi/
-||www.news24.jp/css/adjust.css
+!||ntv.co.jp/ad-navi/
+||news24.jp/css/adjust.
 www.news24.jp###adText01
 
 !MBS動画イズム
@@ -1395,7 +1395,7 @@ news.tbs.co.jp##.md-banner300x250
 ||ad.auditude.com^
 !||vo.ad-v.jp^
 ||ad-v.jp^
-||www.tbs.co.jp/muryou-douga/setting/cuAdControl_v8_utf8.js
+||tbs.co.jp/muryou-douga/setting/cuAdControl_v8_utf8.
 www.tbs.co.jp##.over:has( > .wrap > .recta_bg )
 
 !フジテレビ
@@ -1408,14 +1408,14 @@ www.tv-tokyo.co.jp###txcms_cms_headerBanner
 www.tv-tokyo.co.jp##.tbcms_ad-block
 
 !BSテレ東
-||www.bs-tvtokyo.co.jp/tbcms/javascripts/ad.js
+||bs-tvtokyo.co.jp/tbcms/javascripts/ad.
 www.bs-tvtokyo.co.jp###txcms_cms_headerBanner
 www.bs-tvtokyo.co.jp##.tbcms_ad-block
 
 !テレビ朝日
 !tv-asahi.co.jp##.init-ad-wrapper
 tv-asahi.co.jp##.init-ad
-||www.tv-asahi.co.jp/Top16/pc/scripts/adtech-desktop.js
+||tv-asahi.co.jp/Top16/pc/scripts/adtech-desktop.
 !Chromeでこれ見られなくない？
 !https://cu.tv-asahi.co.jp/watch/1271
 !https://egg.5ch.net/test/read.cgi/software/1551423520/345
@@ -1446,9 +1446,9 @@ mainichi.jp###cxArticleBnrcce
 mainichi.jp###cxPageModalBnr
 
 !スポニチ
-||www.sponichi.co.jp/ad_new/
-||www.sponichi.co.jp/css/ad.css
-||www.sponichi.co.jp/css/common/ad_freepage.css
+||sponichi.co.jp/ad_new/
+||sponichi.co.jp/css/ad.css
+||sponichi.co.jp/css/common/ad_freepage.
 ||ad.jp.ap.valuecommerce.com^
 www.sponichi.co.jp###ad
 www.sponichi.co.jp##div[id^="crt"]
@@ -1466,20 +1466,20 @@ www.nikkansports.com###sideAd1
 www.nikkansports.com###sideAd2
 ||beacon.nikkansports.com^
 www.nikkansports.com##.ad-area
-||www.nikkansports.com/advertising/
+||nikkansports.com/advertising/
 
 !スポーツ報知
 www.hochi.co.jp##.ad_rectangle + script + div
-||www.hochi.co.jp/h_common/img/ad/nsk_banner_2017.gif
+||hochi.co.jp/h_common/img/ad/nsk_banner_2017.
 hochi.news##.ad
 hochi.news##amp-ad
 
 !東スポ
 !gif広告がちかちかしてうざい
-!||www.tokyo-sports.co.jp/wp-content/themes/tospo/images/common/banner_reqruit_140526.gif
-!||www.tokyo-sports.co.jp/wp-content/uploads/2012/02/003.gif
+!||tokyo-sports.co.jp/wp-content/themes/tospo/images/common/banner_reqruit_140526.
+!||tokyo-sports.co.jp/wp-content/uploads/2012/02/003.
 !www.tokyo-sports.co.jp##.adsbygoogle
-!||www.tokyo-sports.co.jp/wp-content/themes/tospo/images/common/miyasaka.gif
+!||tokyo-sports.co.jp/wp-content/themes/tospo/images/common/miyasaka.
 ||img.tokyo-sports.co.jp/wp-content/uploads/2019/07/banner.gif|
 ||img.tokyo-sports.co.jp/wp-content/uploads/2019/09/t-spo_300-100.gif|
 www.tokyo-sports.co.jp##.side-bnr 
@@ -1490,7 +1490,7 @@ www.tokyo-sports.co.jp##.recommend-box.post-list-box
 www.news-postseven.com##.banner
 www.news-postseven.com##.inner-ad
 !www.news-postseven.com###mailmag2
-||www.news-postseven.com/img3_renew/banner/
+||news-postseven.com/img3_renew/banner/
 www.news-postseven.com##a[href$="?_from=sidebanner"]
 
 !女性自身
@@ -1506,12 +1506,12 @@ www.sanspo.com##.adRectangleBanner
 !sanspo.comで検索が機能しない
 !https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/226
 @@||popin.cc^$3p,domain=sanspo.com
-||www.google.co.jp/afs/ads
+||google.co.jp/afs/ads
 www.sanspo.com###ads_content_top
 
 
 !ロイター
-||www.reuters.com/reuters_ads_framework.js
+||reuters.com/reuters_ads_framework.
 !トラッキング
 ||qsearch.media.net/log?
 ||async01.admantx.com^
@@ -1524,9 +1524,9 @@ investing.com###PromoteSignUpPopUp
 !西日本新聞
 ||luxa.sslcs.cdngc.net/dynimg/
 !www.nishinippon.co.jp##.NP-subContentsSection
-||s3-ap-northeast-1.amazonaws.com/luxa/banner/nnp_widget.html
-||www.nishinippon.co.jp/bn/images/bn_epaper_billboard.jpg
-||www.nishinippon.co.jp/mobile/common/img/bn_eppaper_header.jpg
+||s3-ap-northeast-1.amazonaws.com/luxa/banner/nnp_widget.
+||nishinippon.co.jp/bn/images/bn_epaper_billboard.
+||nishinippon.co.jp/mobile/common/img/bn_eppaper_header.
 
 !神戸新聞
 www.kobe-np.co.jp##.newsfeedList_new > .native
@@ -1590,10 +1590,10 @@ m.yna.co.kr##.foreign-ad01
 m.yna.co.kr##.foreign-ad02
 
 !京都新聞
-||www.kyoto-np.co.jp/koukoku/adlist_article.js
-||www.kyoto-np.co.jp/koukoku/image/ad_citykyoto0910.gif
-||www.kyoto-np.co.jp/koukoku/banner.php
-||www.kyoto-np.co.jp/koukoku/image/kcg-edu.gif
+||kyoto-np.co.jp/koukoku/adlist_article.
+||kyoto-np.co.jp/koukoku/image/ad_citykyoto0910.
+||kyoto-np.co.jp/koukoku/banner.php
+||kyoto-np.co.jp/koukoku/image/kcg-edu.
 www.kyoto-np.co.jp##.headerAdArea
 www.kyoto-np.co.jp##.BnrLnkSbs
 
@@ -1621,7 +1621,7 @@ srad.jp##.srad-contentad-banner
 ||cdn-social.janrain.com^
 ||ads.pro-market.net/ads/scripts/site-
 ||ml314.com^
-||www.stack-sonar.com/ping.js
+||stack-sonar.com/ping.js
 ||tag.crsspxl.com/s1.js?
 ||rpxnow.com/js/lib/login.slashdot.org/engage.js
 ||a.fsdn.com/sd/js/scripts/min/deals-min.js?
@@ -1672,9 +1672,9 @@ www.itmedia.co.jp###ITRR
 www.itmedia.co.jp###ITR
 www.itmedia.co.jp###ITN
 www.itmedia.co.jp###ITT
-||www.itmedia.co.jp/css/news/ad.css
-||www.itmedia.co.jp/js/ad.js
-||www.itmedia.co.jp/js/news/ad.js
+||itmedia.co.jp/css/news/ad.
+||itmedia.co.jp/js/ad.js
+||itmedia.co.jp/js/news/ad.
 ||dlv.itmedia.jp/adsv/
 ||adserver.cxad.cxense.com^
 www.itmedia.co.jp##.colBox.colBoxArtTopRcm
@@ -1683,10 +1683,10 @@ www.itmedia.co.jp##.colBox.colBoxArtTopRcm
 !||cdn.cxense.com/cx.js
 ||beacon.watch.impress.co.jp/measure
 !itmedia検索時の広告
-||www.google.com/afs/ads?
+||google.com/afs/ads?
 itmedia.co.jp###ads_content_top
-||www.itmedia.co.jp/js/pcuser/ad.js
-||www.itmedia.co.jp/css/pcuser/ad.css
+||itmedia.co.jp/js/pcuser/ad.
+||itmedia.co.jp/css/pcuser/ad.
 ||static.ads-twitter.com/uwt.js
 www.itmedia.co.jp###body_insert_ad
 itmedia.co.jp##iframe[id^="cxWidget_"]
@@ -1701,10 +1701,10 @@ www.atmarkit.co.jp###body_insert_ad
 www.atmarkit.co.jp###rrec
 www.atmarkit.co.jp##.dmp-area
 www.atmarkit.co.jp###dmp
-||cse.google.com/adsense/search/async-ads.js
-||www.atmarkit.co.jp/js/ait/ex_adRequest.js
-||www.atmarkit.co.jp/js/ad.js
-||www.atmarkit.co.jp/js/ait/ad.js
+||cse.google.com/adsense/search/async-ads.
+||atmarkit.co.jp/js/ait/ex_adRequest.
+||atmarkit.co.jp/js/ad.js
+||atmarkit.co.jp/js/ait/ad.
 
 
 ! ぐるなび
@@ -1744,7 +1744,7 @@ wikiwiki.jp###menubar > div[style="width:240px;height:207px;margin: 5px auto;"]:
 wikiwiki.jp###menubar > div[style="width:240px;height:207px;margin: 5px auto;"]:first-child + p
 
 !msn
-||www.msn.com/advertisement.ad.js
+||msn.com/advertisement.ad.
 ||aolcdn.com/ads/
 ||ads.linkedin.com^
 !誤爆
@@ -1849,7 +1849,7 @@ ign.com##.preShell
 jp.ign.com###adkit_billboard
 
 !Tumblr
-||www.tumblr.com/assets/src/scripts/tumblr/dashboard/showads.js
+||tumblr.com/assets/src/scripts/tumblr/dashboard/showads.
 www.tumblr.com##.dfp-ad-container
 www.tumblr.com###sidebar-ad
 
@@ -1878,7 +1878,7 @@ bing.com##.b_algo:has( > div.b_caption > p:matches-css-before(content: "広告")
 bing.com##^#b_results > .b_ad
 
 !ちくわニコ生ランキング
-||www.chikuwachan.com/live/img/ad/
+||chikuwachan.com/live/img/ad/
 !www.chikuwachan.com##.c
 www.chikuwachan.com###live_index > .c
 
@@ -1905,9 +1905,9 @@ tenki.jp##.tenki-ad-pc-ct
 
 !navitime
 www.navitime.co.jp###under-advertisement
-||www.navitime.co.jp/static/pc/l/3.2.9/js/lib/jquery.adcount.js
-||www.navitime.co.jp/static/pc/l/3.2.9/js/view/transfer/resultAd.js
-||www.navitime.co.jp/naviad/
+||navitime.co.jp/static/pc/l/3.2.9/js/lib/jquery.adcount.
+||navitime.co.jp/static/pc/l/3.2.9/js/view/transfer/resultAd.
+||navitime.co.jp/naviad/
 ||api-pc-img.cld.navitime.jp/images/http://www.navitime.co.jp/advertize_image/
 www.navitime.co.jp##.ad-frame
 
@@ -1947,9 +1947,9 @@ news.biglobe.ne.jp###SPbanner
 ||deliver.ads2.iid.jp^
 !beacon
 ||widget.iid-network.jp^
-||www.gamespark.jp/base/scripts/infinite_scroll_article_cxense_ad_tracking.js
-||www.gamespark.jp/feature/jackAD/
-||www.gamespark.jp/feature/advertising/
+||gamespark.jp/base/scripts/infinite_scroll_article_cxense_ad_tracking.
+||gamespark.jp/feature/jackAD/
+||gamespark.jp/feature/advertising/
 www.gamespark.jp###danglingList
 www.gamespark.jp##li.item:has(> a > article > img[alt^="【PR】"])
 www.gamespark.jp##section.item:has(> a > img[alt^="【PR】"])
@@ -1999,7 +1999,7 @@ spotify.com##.ads-container__inner
 !||open.spotify.com/log/pageview
 
 !Buzzfeed
-||www.buzzfeed.com/static/js/advertiser/
+||buzzfeed.com/static/js/advertiser/
 !SNSが点滅する
 !https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/221
 !||abeagle-public.buzzfeed.com^
@@ -2061,11 +2061,11 @@ exblog.jp##a[href^="http://www.dmm.co.jp/pr/dc/pcgame/"]
 ||pubmine.com/adve
 
 !テレビドラマデータベース
-!||www.tvdrama-db.com/cgi-bin/Amazon/amzCastNameAsin.pl?code=
-!||www.tvdrama-db.com/cgi-bin/Amazon/js/amz.js
-!||www.tvdrama-db.com/cgi-bin/Amazon/amzext1.pl?id=
-!||www.tvdrama-db.com/cgi-bin/Amazon/amzCastName.pl?keyword=
-||www.tvdrama-db.com/cgi-bin/Amazon/
+!||tvdrama-db.com/cgi-bin/Amazon/amzCastNameAsin.pl?code=
+!||tvdrama-db.com/cgi-bin/Amazon/js/amz.
+!||tvdrama-db.com/cgi-bin/Amazon/amzext1.pl?id=
+!||tvdrama-db.com/cgi-bin/Amazon/amzCastName.pl?keyword=
+||tvdrama-db.com/cgi-bin/Amazon/
 
 !朝鮮日報
 www.chosunonline.com##.in_ad
@@ -2079,13 +2079,13 @@ www.chosunonline.com##ul._popIn_infinite_page > li:has( > a._popIn_recommend_art
 japanese.joins.com##.sponsor_link
 
 ! TripadvisorとExpedia
-||www.tripadvisor.jp/GARecord|$xmlhttprequest
+||tripadvisor.jp/GARecord|$xmlhttprequest
 ||static.tacdn.com/js3crawlable/build/concat/taevents-$script
-||www.tripadvisor.jp/BALinkImpressionTracking/$xmlhttprequest
-||www.expedia.co.jp/cl/$xmlhttprequest
-||www.expedia.co.jp/userHistory/count?$xmlhttprequest
+||tripadvisor.jp/BALinkImpressionTracking/$xmlhttprequest
+||expedia.co.jp/cl/$xmlhttprequest
+||expedia.co.jp/userHistory/count?$xmlhttprequest
 ||b.travel-assets.com/travel-pixel-js/$script
-||www.expedia.co.jp/api/datacapture/track|$xmlhttprequest
+||expedia.co.jp/api/datacapture/track|$xmlhttprequest
 
 ! ぐるなび
 ||c-r.gnst.jp/r/campaign/banner_point_outside.png?
@@ -2093,13 +2093,13 @@ japanese.joins.com##.sponsor_link
 www.gnavi.co.jp##.ftb
 
 ! techmemo.biz
-||www.image-rentracks.com^
+||image-rentracks.com^
 
 !pastebin
 pastebin.com##.OUTBRAIN
 ||aj2073.online^
 pastebin.com##div[class^="banner_"]
-||www.ledgerwallet.com/images/promo/banners/
+||ledgerwallet.com/images/promo/banners/
 
 
 
@@ -2137,7 +2137,7 @@ pastebin.com##div[class^="banner_"]
 ! DHC,カタログハウス,クラブツーリズム
 /js/baynote.js|
 /baynote-$script
-||www.dhc.co.jp/script/sitecatalyst/VisitorAPI.js?
+||dhc.co.jp/script/sitecatalyst/VisitorAPI.js?
 ||smetrics.dhc.co.jp/id?$script
 ! ファンケル,カタログハウス
 ||aucollector.tealeaf.ibmcloud.com/collector/$xmlhttprequest
@@ -2155,7 +2155,7 @@ pastebin.com##div[class^="banner_"]
 !||ybx.yahoo.co.jp^
 
 ! じゃらん
-||www.jalan.net/hacci_beacon/sp_yad_search_list.min.js?
+||jalan.net/hacci_beacon/sp_yad_search_list.min.js?
 
 ! 日刊スポーツ
 ||cache1.nipc.jp/js/beacon.js|
@@ -2196,9 +2196,9 @@ pastebin.com##div[class^="banner_"]
 ! RBB Today
 ||s.rbbtoday.com/feature/cxense/js/cx-scrolldepth.js|
 ! Business Insider
-||www.businessinsider.jp/asset/common/app/pv_count.js|
+||businessinsider.jp/asset/common/app/pv_count.js|
 ! マカフィー
-||www.mcafee.com/japan/home/common/js/analytics.js|
+||mcafee.com/japan/home/common/js/analytics.js|
 ! NHK
 ||www3.nhk.or.jp/news/json16/sdc.json?$xmlhttprequest
 ||www3.nhk.or.jp/news/parts16/js/chartbeat_config.js|
@@ -2217,14 +2217,14 @@ pastebin.com##div[class^="banner_"]
 
 
 !http://marketcapitalizations.com/historical-data/historical-components-sp-100/
-!||www.google.com/adsense/domains/caf.js
-!||www.google.com/adsense/
+!||google.com/adsense/domains/caf.js
+!||google.com/adsense/
 
 
 !下記三つはページ内の関連リンクなのであってよい、なくてもよい
-||www.google.com/adsense/domains/caf.js
-||www.google.com/dp/ads?
-||www.gstatic.com/domainads/
+||google.com/adsense/domains/caf.
+||google.com/dp/ads?
+||gstatic.com/domainads/
 
 
 ||parking.parklogic.com/page/enhance.js
@@ -2338,14 +2338,14 @@ pastebin.com##div[class^="banner_"]
 
 !こういうのはワードプレスがクラッキングされているらしい
 !http://www.dhzqj.co/18/blogram-%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF-adblock-plus-%E6%97%A5%E6%9C%AC%E5%90%91%E3%81%91%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF/
-||www.jjtiao.xyz^
-||www.rdzwry.xyz^
+||jjtiao.xyz^
+||rdzwry.xyz^
 ||dmgdelivery20.live^
 
 
 !http://akb48taimuzu.livedoor.biz/archives/24220321.html
 ||lowaihoo15.live^
-||www.wosemdesy.site^
+||wosemdesy.site^
 
 !http://page.freett.com/wagainochi/page1/page.html
 !||mifttreppels14.live^

--- a/mochi_filter.txt
+++ b/mochi_filter.txt
@@ -177,9 +177,12 @@ www.yahoo.co.jp###windowShade
 !上部いい買物の日
 !www.yahoo.co.jp###Peron
 !www.yahoo.co.jp##img[alt="いい買物の日"][src="https://s.yimg.jp/images/evt/kaimono/2019/ytop/pc/ws_1980_70.png"]:upward(1)
+!#if !env_firefox
 www.yahoo.co.jp##img[alt="いい買物の日"][src^="https://s.yimg.jp/images/evt/kaimono/"]:upward(1)
+!#endif
+!#if env_firefox
 www.yahoo.co.jp##^img[alt="いい買物の日"][src^="https://s.yimg.jp/images/evt/kaimono/"]:upward(1)
-
+!#endif
 !「背景を閉じる」
 !→もういらないような気がする
 !www.yahoo.co.jp###windowShade
@@ -1875,8 +1878,12 @@ bing.com##.b_ad
 www.bing.com##li:has( > ul > li > div > h2.b_ads1line )
 bing.com##.b_algo:has( > div.b_caption > p:matches-css-before(content: "Ad"))
 bing.com##.b_algo:has( > div.b_caption > p:matches-css-before(content: "広告"))
+!#if !env_firefox
+bing.com###b_results > .b_ad
+!#endif
+!#if env_firefox
 bing.com##^#b_results > .b_ad
-
+!#endif
 !ちくわニコ生ランキング
 ||chikuwachan.com/live/img/ad/
 !www.chikuwachan.com##.c

--- a/mochi_filter.txt
+++ b/mochi_filter.txt
@@ -911,7 +911,6 @@ bbspink.com###top_banner
 
 !したらば
 !||spad.i-mobile.co.jp^
-!||a.adimg.net^
 jbbs.shitaraba.net##iframe[id^="ox_"]
 jbbs.shitaraba.net##.ad-320_50
 !||blog.seesaa.jp/oem_contents/popular_article_ads/jbbs.js
@@ -1641,7 +1640,6 @@ slashdot.org##.advertisement
 
 
 !Naverまとめ
-||api.unthem.com/js/pcad.js?
 ||cdn-matome.line-apps.com/n/matome/js/nj.matome.ad.yahooim.floating_
 matome.naver.jp###yads_pc_overlay
 

--- a/tamago_filter.txt
+++ b/tamago_filter.txt
@@ -44,15 +44,15 @@ hs-exp.jp##.dfad
 ||ad.pr.ameba.jp^
 ||ssl-stat.amebame.com/pub/ads/
 ||adt.measure.ameblo.jp^
-||www.google.com/ads/
+||google.com/ads/
 !||stats.g.doubleclick.net^$third-party
 !一旦やめとく。PCでブログが表示されないので。2019.1.28
 !ameblo.jp##.skinBody2 > div:first-child
 !ameblo.jp##^.skinBody2 > div:first-child
 !モデルプレス mdpr.jp でスクロールすると…な画像がスクロールしても表示されない
 !https://egg.5ch.net/test/read.cgi/android/1554363290/741
-!||www.googletagmanager.com^
-||www.googletagmanager.com^$domain=ameblo.jp
+!||googletagmanager.com^
+||googletagmanager.com^$domain=ameblo.jp
 !||click.amanad.adtdp.com^
 !||ad.caprofitx.adtdp.com^
 !埋め込み動画が消えてしまう
@@ -74,39 +74,39 @@ hs-exp.jp##.dfad
 ameblo.jp##div[role="navigation"]
 
 ! TripadvisorとExpedia
-||www.tripadvisor.jp/GARecord|$xmlhttprequest
+||tripadvisor.jp/GARecord|$xmlhttprequest
 ||static.tacdn.com/js3crawlable/build/concat/taevents-$script
-||www.tripadvisor.jp/BALinkImpressionTracking/$xmlhttprequest
-||www.expedia.co.jp/cl/$xmlhttprequest
-||www.expedia.co.jp/userHistory/count?$xmlhttprequest
+||tripadvisor.jp/BALinkImpressionTracking/$xmlhttprequest
+||expedia.co.jp/cl/$xmlhttprequest
+||expedia.co.jp/userHistory/count?$xmlhttprequest
 ||b.travel-assets.com/travel-pixel-js/$script
-||www.expedia.co.jp/api/datacapture/track|$xmlhttprequest
+||expedia.co.jp/api/datacapture/track|$xmlhttprequest
 
 !Youtube
 !https://m.youtube.com/
-||www.google.co.jp/pagead/
-||www.youtube.com/api/stats/ads?
+||google.co.jp/pagead/
+||youtube.com/api/stats/ads?
 ||m.youtube.com/csi_204?
-||www.youtube.com/pagead/
+||youtube.com/pagead/
 !Youtube,Home最上部の広告動画
 !###koya_child_5 > div:first-child
 !###koya_child_6
 youtube.com##ytm-promoted-video-renderer
 
 !Youtubeパソコン用からのコピペ
-||www.youtube.com/yts/jsbin/www-pagead-id-
+||youtube.com/yts/jsbin/www-pagead-id-
 !||googleads.g.doubleclick.net^
 ||youtube.com/get_midroll_
 ||pagead2.googlesyndication.com^
 youtube.com##.ad-container
 youtube.com##.video-ads
 youtube.com##.ytp-ad-progress-list
-!||www.google.co.jp/pagead/lvz?
+!||google.co.jp/pagead/lvz?
 !||static.doubleclick.net/instream/ad_status.js
 youtube.com###player-ads
 !||pubads.g.doubleclick.net^
 ||youtube.com/pagead/
-||www.youtube.com/ads/$image
+||youtube.com/ads/$image
 !||securepubads.g.doubleclick.net
 =adunit&$domain=youtube.com
 !Peter Lowe’s Ad and tracking server listで一括ブロックされている
@@ -237,7 +237,7 @@ watch.impress.co.jp###sp-floating-layer
 !Yahoo!Japan
 ||s.yimg.jp/images/listing/tool/yads/
 ||smartads.mobile.yahoo.co.jp/MobileAds/
-||www.jiji.com/smp/common/css/yads.css
+||jiji.com/smp/common/css/yads.
 ||i.yimg.jp/images/listing/tool/yads/yads-timeline-ex.js
 ||s.yimg.jp/bdv/prem/
 m.yahoo.co.jp##.PremiumFirst
@@ -330,7 +330,7 @@ creators.yahoo.co.jp##.FixedButtons
 
 ! 楽天
 !/akam/11/*
-!||www.rakuten.co.jp/akam/11/
+!||rakuten.co.jp/akam/11/
 !/akam/11/*
 ||r.r10s.jp/com/js/omniture/plugin/sc_trackingid.js|
 ||ias.rakuten.co.jp/gw.js?$subdocument
@@ -489,7 +489,7 @@ buzzfeed.com###mod-action-bar-1
 ||google-analytics.com^
 ||quantserve.com^
 ||crwdcntrl.net^
-||www.buzzfeed.com/static/js/advertiser/ads.js
+||buzzfeed.com/static/js/advertiser/ads.
 
 !斧
 ||bn.maist.jp^
@@ -503,7 +503,7 @@ www.axfc.net##.bnf
 ||adntokyo.gunosy.com^
 
 !sankei
-||www.sankei.com/apr_news/js/others/adGpt.js
+||sankei.com/apr_news/js/others/adGpt.
 ||sankei2ad.durasite.net^
 www.sankei.com###footerFloatingMenu
 www.sankei.com##.ad
@@ -520,12 +520,12 @@ www.sankeibiz.jp##.ad
 !||i.yimg.jp/images/listing/tool/yads/yads-timeline-ex.js
 !パソコンでradikoが聞けない
 !||assets.adobedtm.com^
-!||www.asahicom.jp/ad/js/sp/top.js
+!||asahicom.jp/ad/js/sp/top.js
 !サムネがでない
-!||www.asahicom.jp/and/js/and_infeedad.js
-||www.asahi.com/ad/count.htm
+!||asahicom.jp/and/js/and_infeedad.
+||asahi.com/ad/count.
 ||sp.gmossp-sp.jp^
-||www.asahicom.jp/ad/
+||asahicom.jp/ad/
 www.asahi.com###NativePr
 www.asahi.com###OutbrainRec
 www.asahi.com##.PrInfoBlock
@@ -535,9 +535,9 @@ www.asahi.com##.AdArea
 www.asahi.com##.ad-1stbnr.ad
 
 !Yomiuri
-!||www.yomiuri.co.jp/cont2/ad/js/sp_ad_home.js
+!||yomiuri.co.jp/cont2/ad/js/sp_ad_home.
 ||cdn.gmossp-sp.jp^
-||www.yomiuri.co.jp/cont2/ad/
+||yomiuri.co.jp/cont2/ad/
 sp.yomiuri.co.jp##.social-buttons-overlay
 
 !日経
@@ -572,8 +572,8 @@ mainichi.jp###bottom-share
 ||cdn.mainichi.jp/vol1/js/sp/share.js
 
 !時事通信
-!||js.mtburn.com/advs-instream.js
-||www.jiji.com/smp/common/css/yads2.css
+!||js.mtburn.com/advs-instream.
+||jiji.com/smp/common/css/yads2.
 ||us-ads.openx.net^
 !||rd.adingo.jp^
 !||i.adingo.jp^
@@ -614,9 +614,9 @@ www.sanspo.com##.ad
 bunshun.jp##.horizontal-sns-bar
 
 !zdnet
-||www.aiasahi.jp/ads/
-||japan.zdnet.com/parts/frame/ad_tieup_control_sp.htm
-||japan.zdnet.com/parts/frame/ad_sp_list_a_n.htm
+||aiasahi.jp/ads/
+||japan.zdnet.com/parts/frame/ad_tieup_control_sp.
+||japan.zdnet.com/parts/frame/ad_sp_list_a_n.
 ||japan.zdnet.com/media/ad/
 japan.zdnet.com##.ad-text
 
@@ -771,17 +771,17 @@ weblio.jp##.adBkOverlayClr
 !||connect.facebook.net/en_US/fbadnw55.js
 ||connect.facebook.net/ja_JP/sdk.js
 ||weblio.hs.llnwd.net/e7/jsad/cp404.js
-!||www.facebook.com/impression.php^$domain=ejje.weblio.jp
-!||www.facebook.com/v2.5/plugins/page.php?adapt_container_width=$domain=ejje.weblio.jp
+!||facebook.com/impression.php^$domain=ejje.weblio.jp
+!||facebook.com/v2.5/plugins/page.php?adapt_container_width=$domain=ejje.weblio.jp
 ejje.weblio.jp##.adBannerHdWrp
 !ejje.weblio.jp##^.adBannerHdWrp
 !https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/217
 !ejje.weblio.jp##amp-sidebar
 !ejje.weblio.jp##^amp-sidebar
 !ejje.weblio.jp##^.hideAdRnwWrp
-!||cdn.ampproject.org/v0/amp-ad-0.1.js
-||cdn.ampproject.org/v0/amp-sticky-ad-1.0.js
-!||weblio.hs.llnwd.net/e7/script/include/house_ad_on_load_modal_smp.js
+!||cdn.ampproject.org/v0/amp-ad-0.1.
+||cdn.ampproject.org/v0/amp-sticky-ad-1.0.
+!||weblio.hs.llnwd.net/e7/script/include/house_ad_on_load_modal_smp.
 !||weblio.hs.llnwd.net/e7/img/muryo_banner_
 !||weblio.hs.llnwd.net/e7/img/theme_learning_banner
 !||weblio.hs.llnwd.net/e7/img/icons/theme-learning-600-500.png
@@ -837,20 +837,20 @@ b.hatena.ne.jp###global-header:style(top: 0px !important)
 b.hatena.ne.jp##.js-smart-app-banner-container::before:style(height: 0px !important)
 
 !現代ビジネス
-||gendai.ismcdn.jp/resources/gb/js/v3/gb_change_ad_margin.js
-||gendai.ismcdn.jp/resources/gb/js/v3/gb_load_inArticle_ad.js
+||gendai.ismcdn.jp/resources/gb/js/v3/gb_change_ad_margin.
+||gendai.ismcdn.jp/resources/gb/js/v3/gb_load_inArticle_ad.
 ||rt.rtoaster.jp^
 ||gendai.ismedia.jp/list/v3-ad-inArticle/
 ||comcluster.cxense.com^
 gendai.ismedia.jp##.ad-in-article
 
 !FNN
-||www.fnn-news.com/sp/news/data/uliza/ad_exclude_sitejack.json
+||fnn-news.com/sp/news/data/uliza/ad_exclude_sitejack.
 ||aka-secure-img.uliza.jp/html5/fnn/ad/
 ||fistag2.fis.fujitv.co.jp/pc/space.gif
 www.fnn-news.com###footAd
 www.fnn-news.com###overLay
-||www.fnn-news.com/material/img/downloadnow.png
+||fnn-news.com/material/img/downloadnow.
 www.fnn-news.com##.appinfo
 fnn.jp##.Ad
 ||amazon-adsystem.com^$domain=fnn.jp
@@ -859,13 +859,13 @@ fnn.jp##.Ad
 /ulizahtml5-advertising.min.js|$domain=fnn.jp
 
 !西日本新聞
-||cdn.apvdr.com/js/VastAdUnit.min.js
+||cdn.apvdr.com/js/VastAdUnit.
 ||apvdr.com/v2/cs.php
 ||tr.quant.jp^
-!||cdn.treasuredata.com/sdk/1.7.1/td.min.js
+!||cdn.treasuredata.com/sdk/1.7.1/td.
 ||static.quant.jp/lait.js
 www.nishinippon.co.jp##.recommend
-!||www.nishinippon.co.jp/mobile/common/img/bn_epaper_header_1anniv.png
+!||nishinippon.co.jp/mobile/common/img/bn_epaper_header_1anniv.png
 
 !Daily News Online
 !||ds.advg.jp^
@@ -888,7 +888,7 @@ mainichi.jp##.ad
 tech.nikkeibp.co.jp##.footer_nav
 ! 日経BPトラッカー
 !/js/bpcommon/onetag/bpTrackVars$script
-!||www.nikkeibp.co.jp/js/bpcommon/onetag/bpTrackVars$script
+!||nikkeibp.co.jp/js/bpcommon/onetag/bpTrackVars$script
 /js/bpcommon/onetag/bpTrackVars$script
 
 !ユルクヤル http://yurukuyaru.com
@@ -923,14 +923,14 @@ tokyograffiti.grfft.jp##.fixbtn
 !||bunshun.jp/oo/bs/m.gif?
 !||gendai.ismedia.jp/oo/im/m.gif?
 !||diamond.jp/oo/d/m.gif?
-!||www.dhbr.net/oo/d/m.gif?
+!||dhbr.net/oo/d/m.gif?
 ||bunshun.jp/oo/
 ||gendai.ismedia.jp/oo/
 ||diamond.jp/oo/
-||www.dhbr.net/oo/
+||dhbr.net/oo/
 
 !cnn.co.jp
-||www.cnn.co.jp/media/cnn/images/mini/ad_bg.png
+||cnn.co.jp/media/cnn/images/mini/ad_bg.
 !||z.moatads.com^
 ||smetrics.cnn.com/b/ss/cnn-adbp-offsite-domestic/
 !||bea4.v.fwmrm.net/ad/
@@ -987,12 +987,12 @@ linuxnorth.wordpress.com##.wpcnt
 jp.sputniknews.com##.social-likes-pane
 ||ads.adfox.ru^
 ||yastatic.net/pcode/adfox/loader.js
-||jp.sputniknews.com/min/js/libs/adriver.core.2.js
-||jp.sputniknews.com/min/js/libs/adfox.asyn.code.ver3-scroll.js
+||jp.sputniknews.com/min/js/libs/adriver.core.2.
+||jp.sputniknews.com/min/js/libs/adfox.asyn.code.ver3-scroll.
 jp.sputniknews.com###smartbanner
 !jp.sputniknews.com##html:style(margin-top: 0px;)
 !jp.sputniknews.com##html:style(margin-top: 0px;)
-||jp.sputniknews.com/min/js/plugins/jquery.smartbanner.js
+||jp.sputniknews.com/min/js/plugins/jquery.smartbanner.
 
 
 !carnnyマガジン
@@ -1010,7 +1010,7 @@ www.bengo4.com##div[id^="ad-slot-"]
 netgeek.biz##.showcase-location-header
 
 !ロイター
-||www.reuters.com/reuters_ads_framework.js
+||reuters.com/reuters_ads_framework.
 ||async01.admantx.com^
 !||cdn.adsafeprotected.com^
 !トラッキング
@@ -1023,8 +1023,8 @@ jp.reuters.com##div[data-template="footer"]
 !映画.com
 !Googleショッピングで商品クリックで飛べない
 !https://egg.5ch.net/test/read.cgi/software/1540428057/406
-!||www.googleadservices.com^
-||www.googleadservices.com^$domain=eiga.com
+!||googleadservices.com^
+||googleadservices.com^$domain=eiga.com
 eiga.com##.adBox-a
 eiga.com###rect_ad
 
@@ -1075,7 +1075,7 @@ togetter.com##^.appdl_header
 !デイリー
 www.daily.co.jp##.adv
 ||jpmarket-d.openx.net^
-||www.daily.co.jp/ad/
+||daily.co.jp/ad/
 
 !まいじつ
 myjitsu.jp##.sp-single-below-sns-buttons
@@ -1156,8 +1156,8 @@ www.nikkan-gendai.com###_popIn_recommend_2
 m.slashdot.org##.ad-on
 
 !animatetimes
-||www.animatetimes.com/ad/
-||cdn.fivecdm.com/adsbyfive.js
+||animatetimes.com/ad/
+||cdn.fivecdm.com/adsbyfive.
 ||api.flipdesk.jp^
 
 
@@ -1206,7 +1206,7 @@ theverge.com##.tab-bar-fixed
 
 
 !techcrunch.com
-||www.npttech.com/advertising.js
+||npttech.com/advertising.js
 techcrunch.com##.social-share-fixed
 techcrunch.com##.header-ad
 
@@ -1232,7 +1232,7 @@ japanese.engadget.com##div[class^="js-"]:has( iframe[src^="//rcm-fe.amazon-adsys
 ||images-fe.ssl-images-amazon.com/images/I/$domain=japanese.engadget.com
 japanese.engadget.com##iframe[src^="//rcm-fe.amazon-adsystem.com"]
 www.engadget.com##.o-mobile-share-footer
-||o.aolcdn.com/ads/adsWrapper.js
+||o.aolcdn.com/ads/adsWrapper.
 japanese.engadget.com##.engadget-share
 
 
@@ -1259,7 +1259,7 @@ www.lifehacker.jp##.lh-postSns
 www.lifehacker.jp##.lh-banner
 www.lifehacker.jp##.lh-globalNav-button
 www.lifehacker.jp##.lh-globalButton
-||assets.media-platform.com/common/js/lib/dfp-ad-manager/dfp-ad-manager.min.js
+||assets.media-platform.com/common/js/lib/dfp-ad-manager/dfp-ad-manager.
 
 !河合塾keinet.ne.jp
 www.keinet.ne.jp###fixedSlideWrapper
@@ -1365,7 +1365,7 @@ gigazine.net###EndFooter
 m.scmp.com##.share-buttons-fixed-container
 
 !西日本新聞
-||www.nishinippon.co.jp/mobile/common/img/bn_eppaper_header.jpg
+||nishinippon.co.jp/mobile/common/img/bn_eppaper_header.
 www.nishinippon.co.jp##a[href^="http://ac.ebis.ne.jp/tr_set.php?argument="]
 
 
@@ -1392,18 +1392,18 @@ shopping.dmkt-sp.jp##.footer
 
 
 !痛いニュース
-!||blog.livedoor.jp/dqnplus/settings/lite2/ads.js
+!||blog.livedoor.jp/dqnplus/settings/lite2/ads.
 ||torimochi.line-apps.com^
 blog.livedoor.jp##.btn-ldb-bottomAdd
 
 !アルファモザイク
-||blogmaterial.nicoblomaga.jp/material/279/SP_alfaad.js
+||blogmaterial.nicoblomaga.jp/material/279/SP_alfaad.
 !||adservice.google.co.jp^
-||blogmaterial.nicoblomaga.jp/material/279/bromaga_AdTimer_SP.js
+||blogmaterial.nicoblomaga.jp/material/279/bromaga_AdTimer_SP.
 !||log.affiliate.rakuten.co.jp^
 
 !ニュー速クオリティ
-!||news4vip.livedoor.biz/settings/lite2/ads.js
+!||news4vip.livedoor.biz/settings/lite2/ads.
 news4vip.livedoor.biz##div[style="background-color: white; padding: 5px; margin: 5px; line-height: 1.9; border: 1px solid rgb(105, 105, 105);"]
 news4vip.livedoor.biz###article-contents > b a
 
@@ -1411,7 +1411,7 @@ news4vip.livedoor.biz###article-contents > b a
 !（なし）
 
 !暇人速報
-||parts.blog.livedoor.jp/js/lite2/ads/infeed.js
+||parts.blog.livedoor.jp/js/lite2/ads/infeed.
 !||adservice.google.co.jp/adsid/google/ui
 
 !VIPPERな俺
@@ -1463,8 +1463,7 @@ matome-plus.com##.amazontotalboxtest
 !||images-fe.ssl-images-amazon.com/images/$domain=blog.esuteru.com
 ||ecx.images-amazon.com/images/$domain=blog.esuteru.com
 blog.esuteru.com##.amazlet-box
-||mcgm.sakura.ne.jp/sp_300x250.php
-||mcgm.sakura.ne.jp/sp_300x250.jpg
+||mcgm.sakura.ne.jp/sp_300x250.
 
 !ねぎ速
 www.negisoku.com###id_1
@@ -1518,8 +1517,8 @@ www.mudainodocument.com##a[href^="http://s.liveads.jp/cc.php"]
 www.mudainodocument.com##a[href^="https://s.liveads.jp/cc.php"]
 www.mudainodocument.com##a[href="https://recott.me/"]
 ||octopuspop.com^
-||blogmaterial.nicoblomaga.jp/material/258/sp-adchange.js
-||blogmaterial.nicoblomaga.jp/material/258/bromaga_AdTimer_SP.js
+||blogmaterial.nicoblomaga.jp/material/258/sp-adchange.
+||blogmaterial.nicoblomaga.jp/material/258/bromaga_AdTimer_SP.
 
 !暇人速報
 !（なし）
@@ -1563,21 +1562,21 @@ blog.livedoor.jp##div[id^="socrun_div_area_nc_"]
 ||social-runner.net/adloader.js
 
 !ニュー即ブログν
-||bibincom.com/ad/187_newsoku.blog.js
+||bibincom.com/ad/187_newsoku.blog.
 
 !やらおん
 yaraon-blog.com##iframe[id="ac1414080be"][src^="http://ads.mulan.cloud/"]
 yaraon-blog.com###adx_custom_ol
 ||ads.mulan.cloud^
-||blog.livelog.biz/script/js/media/v_z/yon_sp02_adstir.js
-||blog.livelog.biz/script/js/yon_sp03_adsense.js
-||blog.livelog.biz/script/js/yon_sp02_adsense.js
-||blog.livelog.biz/script/js/yon_sp01_adsense.js
+||blog.livelog.biz/script/js/media/v_z/yon_sp02_adstir.
+||blog.livelog.biz/script/js/yon_sp03_adsense.
+||blog.livelog.biz/script/js/yon_sp02_adsense.
+||blog.livelog.biz/script/js/yon_sp01_adsense.
 ||ad.adpon.jp^
 yaraon-blog.com###mytextwidget-22
 yaraon-blog.com###mytextwidget-14
 yaraon-blog.com###mytextwidget-27
-||blog.livelog.biz/script/js/media/v_z/yon_nex07_adnico.js
+||blog.livelog.biz/script/js/media/v_z/yon_nex07_adnico.
 adnico.js|$domain=yaraon-blog.com
 adsense.js|$domain=yaraon-blog.com
 
@@ -1611,7 +1610,7 @@ blog.livedoor.jp###apptemp06
 !芸能★アイドル速報♪♪
 !http://geinou-idolu.com/
 ||affiliate.rakuten.co.jp^
-!||www.bijo-toiro.com/blogparts/miss_blogparts.html
+!||bijo-toiro.com/blogparts/miss_blogparts.html
 !||mv-gossip.up.n.seesaa.net/mv-gossip/image/_girls002_imgs_5_7_578d7e01.gif
 
 !暇つぶしニュース
@@ -1660,7 +1659,7 @@ buzz-cafe.net###ist_overlay1
 buzz-cafe.net###ist_overlay2
 
 !!http://www.ttdyhot.net
-!||meerkat.jarodtaylor.com/download/jquery.meerkat.1.3.min.js
+!||meerkat.jarodtaylor.com/download/jquery.meerkat.
 
 !http://ghdnewzealandshopc.com/
 !||ghdnewzealandshopc.com/wp-content/uploads/2018/05/300x250_1-320x267.jpg
@@ -1673,7 +1672,7 @@ monsterhunter.more-gamer.com##.adPopup
 
 
 !ドラドラ動画
-!||www.drive-drive.jp/assets/images/dr_308_62_20171108.jpg
+!||drive-drive.jp/assets/images/dr_308_62_20171108.jpg
 
 
 !今日何食べる.com
@@ -1751,12 +1750,12 @@ cinematoday.jp##.ct-ad-banner
 !dorama9
 !https://dorama9.com/
 ||glssp.jp/GL_AD/
-||www.rentracks.jp/adx/
+||rentracks.jp/adx/
 
 !男子ハック
 !www.danshihack.com
 www.danshihack.com##.p-ad__container--single
-||www.danshihack.com/wp-content/uploads/2018/05/kindle-sale-1.jpg
+||danshihack.com/wp-content/uploads/2018/05/kindle-sale-1.
 www.danshihack.com##.c-banner
 www.danshihack.com##.p-ranking
 
@@ -1776,7 +1775,7 @@ employment.en-japan.com##.entry-footer
 ||gamewith.jp/ad/
 gamewith.jp##.ad-header-creative
 gamewith.jp##.to-btn--deep-link.js-deep-link-block.js-move-with-expand-network-ad
-||gamewith.jp/assets/js/dist/jp/gamewith/ad/index.js
+||gamewith.jp/assets/js/dist/jp/gamewith/ad/index.
 gamewith.jp###js-ad-jack
 gamewith.jp##.c-sp-leaderboard-ad-overlay
 
@@ -1833,8 +1832,8 @@ pandora.tv##.ad_footer
 pandora.tv##.ad_small
 pandora.tv##.advertisement
 ||channel.pandora.tv/channel/view_ad.ptv
-||imgcdn.pandora.tv/_ptv_all/util/makePCookie_pandora_utf.js
-||imgcdn.pandora.tv/ptv_img/icon_network_ad.gif
+||imgcdn.pandora.tv/_ptv_all/util/makePCookie_pandora_utf.
+||imgcdn.pandora.tv/ptv_img/icon_network_ad.
 !動画再生５分後に表示されるプレミアム登録誘導
 channel.pandora.tv##.pm_wrap
 pandora.tv###nx_pause_area > .stopbtn
@@ -1843,14 +1842,14 @@ pandora.tv###nx_pause_area > .stopbtn
 www.copiapoa.jp###fixBanner
 
 !http://ouroboros.hamazo.tv
-||ouroboros.hamazo.tv/js/archive-sp-ad.js
-||ouroboros.hamazo.tv/outside/clog_ad.js
-||www.hamazo.tv/js/staff-sp-ad.js
+||ouroboros.hamazo.tv/js/archive-sp-ad.
+||ouroboros.hamazo.tv/outside/clog_ad.
+||hamazo.tv/js/staff-sp-ad.
 ||log.ti-da.net/ad/
 ouroboros.hamazo.tv###meerkat-wrap
 
 !www.hanamonogatari.com
-||www.hanamonogatari.com/blog/wp-content/themes/hana_thema/images/floating-banner-sp.png
+||hanamonogatari.com/blog/wp-content/themes/hana_thema/images/floating-banner-sp.
 www.hanamonogatari.com##.floatingBn
 
 !belcy.jp
@@ -1858,7 +1857,7 @@ www.hanamonogatari.com##.floatingBn
 
 !All About
 ||primead.jp^
-||pts.aacdn.jp/app/touch-front/js/sp/ad_create.js
+||pts.aacdn.jp/app/touch-front/js/sp/ad_create.
 allabout.co.jp###sys-anchor
 
 !Cyzo Woman
@@ -1871,7 +1870,7 @@ www.cyzo.com##div[id^="ad_"]
 !これはエロい速報
 !http://korewaeroi.com/
 ||adnico.jp^
-||korewaeroi.com/wp-content/wptouch-data/themes/classic-redux-copy-1/default/ad01.php
+||korewaeroi.com/wp-content/wptouch-data/themes/classic-redux-copy-1/default/ad01.
 korewaeroi.com###ad01
 
 !もみあげチャ～シュ～
@@ -1927,7 +1926,7 @@ blog.shinobi.jp##.adBlock
 dailytelegraph.com.au##.tgc-footer-fixed
 ||eyeviewads.com^
 ||gu.dyntrk.com/adx/
-||www.googleadservices.com/pagead/conversion.js
+||googleadservices.com/pagead/conversion.js
 ||adnxs.com^
 ||adsrvr.org^
 
@@ -1957,7 +1956,7 @@ www.pixiv.net##.ad-frame-container
 
 ! Spice
 ||spice.eplus.jp/img/icons/logo/app_icon.jpg
-||spice.eplus.jp/third_party/jasny-jquery.smartbanner/jquery.smartbanner.css
+||spice.eplus.jp/third_party/jasny-jquery.smartbanner/jquery.smartbanner.
 spice.eplus.jp###smartbanner
 
 ! DMM
@@ -2026,14 +2025,14 @@ note.com##.p-article__share
 
 
 !http://marketcapitalizations.com/historical-data/historical-components-sp-100/
-!||www.google.com/adsense/domains/caf.js
-!||www.google.com/adsense/
+!||google.com/adsense/domains/caf.
+!||google.com/adsense/
 
 
 !下記三つはページ内の関連リンクなのであってよい、なくてもよい
-||www.google.com/adsense/domains/caf.js
-||www.google.com/dp/ads?
-||www.gstatic.com/domainads/
+||google.com/adsense/domains/caf.
+||google.com/dp/ads?
+||gstatic.com/domainads/
 
 
 ||parking.parklogic.com/page/enhance.js
@@ -2044,9 +2043,9 @@ note.com##.p-article__share
 !||i.cdnpark.com/registrar/v3/loader.js
 !||d1lxhc4jvstzrp.cloudfront.net/registrar/v3/content/717207
 !||js.parkingcrew.net/jsparkcaf.php?
-!||js.parkingcrew.net/assets/scripts/jsparkcaf.js
+!||js.parkingcrew.net/assets/scripts/jsparkcaf.
 !||js.parkingcrew.net/track.php?domain=
-!||js.parkingcrew.net/assets/scripts/registrar-caf/717207.js
+!||js.parkingcrew.net/assets/scripts/registrar-caf/717207.
 
 !http://umaizoo.com/
 ||tracking.bodis.com/tlpv?
@@ -2146,14 +2145,14 @@ note.com##.p-article__share
 
 !こういうのはワードプレスがクラッキングされているらしい
 !http://www.dhzqj.co/18/blogram-%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF-adblock-plus-%E6%97%A5%E6%9C%AC%E5%90%91%E3%81%91%E3%83%95%E3%82%A3%E3%83%AB%E3%82%BF/
-||www.jjtiao.xyz^
-||www.rdzwry.xyz^
+||jjtiao.xyz^
+||rdzwry.xyz^
 ||dmgdelivery20.live^
 
 
 !http://akb48taimuzu.livedoor.biz/archives/24220321.html
 ||lowaihoo15.live^
-||www.wosemdesy.site^
+||wosemdesy.site^
 
 
 
@@ -2217,7 +2216,7 @@ note.com##.p-article__share
 ! DHC,カタログハウス,クラブツーリズム
 /js/baynote.js
 /baynote-$script
-||www.dhc.co.jp/script/sitecatalyst/VisitorAPI.js?
+||dhc.co.jp/script/sitecatalyst/VisitorAPI.js?
 ||smetrics.dhc.co.jp/id?$script
 ! ファンケル,カタログハウス
 ||aucollector.tealeaf.ibmcloud.com/collector/$xmlhttprequest
@@ -2234,21 +2233,21 @@ note.com##.p-article__share
 !||mikiki.tokyo.jp/oo/mk/m.gif?
 !||toyokeizai.net/oo/tk/m.gif?
 !||ure.pia.co.jp/oo/pia/m.gif?
-!||www.afpbb.com/oo/afp/m.gif?
-!||www.fsight.jp/oo/other/m.gif?
-!||www.jprime.jp/oo/other/m.gif?
+!||afpbb.com/oo/afp/m.gif?
+!||fsight.jp/oo/other/m.gif?
+!||jprime.jp/oo/other/m.gif?
 ||mikiki.tokyo.jp/oo/
 ||toyokeizai.net/oo/
 ||ure.pia.co.jp/oo/
-||www.afpbb.com/oo/
-||www.fsight.jp/oo/
-||www.jprime.jp/oo/
+||afpbb.com/oo/
+||fsight.jp/oo/
+||jprime.jp/oo/
 
 ! トラッキングその他。/js/analytics.jsも誤爆あるようなのでまとめてない
 ! 日刊スポーツ
 ||cache1.nipc.jp/js/beacon.js|
 ! エアトリ
-||cdn.airtrip.jp/js/frontend/sp/ga_event_tracking.js?
+||cdn.airtrip.jp/js/frontend/sp/ga_event_tracking.
 ! 電撃
 ||dengeki.com/js/ga.js|
 ! Bookwalker
@@ -2265,17 +2264,17 @@ note.com##.p-article__share
 ||news.tv-asahi.co.jp/js/analytics.js|
 ! livedoorブログ (Not Found)
 ||parts.blog.livedoor.jp/js/analytics.js|
-||parts.blog.livedoor.jp/js/c2.js?
+||parts.blog.livedoor.jp/js/c2.
 ! Canon
 ||rtbcx.canon.jp/bcx/rt_tag.js|
 ! RBB Today
 ||s.rbbtoday.com/feature/cxense/js/cx-scrolldepth.js|
 ! Business Insider
-||www.businessinsider.jp/asset/common/app/pv_count.js|
+||businessinsider.jp/asset/common/app/pv_count.js|
 ! じゃらん
-||www.jalan.net/hacci_beacon/sp_yad_search_list.min.js?
+||jalan.net/hacci_beacon/sp_yad_search_list.
 ! マカフィー
-||www.mcafee.com/japan/home/common/js/analytics.js|
+||mcafee.com/japan/home/common/js/analytics.js|
 ! NHK
 ||www3.nhk.or.jp/news/json16/sdc.json?$xmlhttprequest
 ||www3.nhk.or.jp/news/parts16/js/chartbeat_config.js|
@@ -2407,7 +2406,7 @@ kinisuru.com##.a2a_floating_style
 !END--------------------------------------------------------------
 
 !https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/54-55
-!||www.gstatic.com^
+!||gstatic.com^
 !https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/56
 
 ! END

--- a/tamago_filter.txt
+++ b/tamago_filter.txt
@@ -500,7 +500,6 @@ www.axfc.net##.bnf
 ||d.href.asia/nw/d/ajs.php?zoneid=
 
 !livedoor.biz
-||api.unthem.com/js/spad.js?
 ||adntokyo.gunosy.com^
 
 !sankei
@@ -1087,7 +1086,6 @@ myjitsu.jp##.ad-header-box
 
 !したらば
 ||spad.i-mobile.co.jp^
-!||a.adimg.net^
 jbbs.shitaraba.net##iframe[id^="ox_"]
 jbbs.shitaraba.net##.ad-320_50
 ||blog.seesaa.jp/oem_contents/popular_article_ads/jbbs.js
@@ -1490,7 +1488,6 @@ www.negisoku.com###id_5
 
 !２ちゃんねるブックマーク
 ||medi-8.net^
-||rdp.pro.ne.jp^
 ||bitflyer.jp^$third-party
 2ch.vet##a[href^="https://clicks.pipaffiliates.com/"]
 !||rdp.pro.ne.jp/img/
@@ -1598,7 +1595,6 @@ gossip1.net##iframe[src^="http://sda.seesaa.jp/"]
 
 !おたくみくす　声優まとめ
 !http://otakumix.doorblog.jp/
-!||js.next-channel.com/adcall.js
 otakumix.doorblog.jp##.t_r
 
 !http://www.akb48matomemory.com

--- a/tamago_filter.txt
+++ b/tamago_filter.txt
@@ -1412,9 +1412,9 @@ shopping.dmkt-sp.jp##.footer
 /settings/lite2/ads.js|
 !まとめ
 !共通
-/itro-scripts.js\?ver=[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$/
-/jquery.modal.js\?ver=[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$/
-/popups.js\?ver=[0-9]{1,2}\.[0-9]{1,2}$/
+/itro-scripts.js\?ver=[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$/$script
+/jquery.modal.js\?ver=[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$/$script
+/popups.js\?ver=[0-9]{1,2}\.[0-9]{1,2}$/$script
 
 
 

--- a/tamago_filter.txt
+++ b/tamago_filter.txt
@@ -279,7 +279,9 @@ search.yahoo.co.jp##div.sw-CardBase:has( > div.sw-Card.AnswerChiebukuro )
 
 !Yahooスポナビ
 ||s.yimg.jp/images/sports/all_device/sp/js/jquery.spInterstitial$script
+!#if env_firefox
 baseball.yahoo.co.jp,soccer.yahoo.co.jp##^script:has-text(instUrl)
+!#endif
 ||s.yimg.jp/images/sports/all_device/common/js/jquery.spDoubleImage.js|
 ||s.yimg.jp/images/sports/all_device/banner/app/$image
 ! スポナビ上部のアプリ広告
@@ -323,7 +325,12 @@ auctions.yahoo.co.jp###footer + section[class^="Component-"]
 !https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/200
 !page.auctions.yahoo.co.jp##^script:has-text(floatBannerData)
 ||s.yimg.jp/images/auct/cms/promo/floating/
+!#if !env_firefox
+page.auctions.yahoo.co.jp##[id^=js-BannerFrame]
+!#endif
+!#if env_firefox
 page.auctions.yahoo.co.jp##^[id^=js-BannerFrame]
+!#endif
 
 !Yahooクリエイターズ
 creators.yahoo.co.jp##.FixedButtons 
@@ -388,9 +395,15 @@ itest.5ch.net###js-cardview_ad
 itest.5ch.net##div[style="height: 320px; position: relative; text-align: center; overflow: hidden; margin: 0 auto; margin-bottom: 15px;"]
 ||mediad2.jp^
 ! 5ch遷移時に出る広告の残骸
+!#if !env_firefox
+itest.5ch.net###interstitial-ad-div-id
+itest.5ch.net###float-bnr
+!#endif
+!#if env_firefox
 itest.5ch.net##^#interstitial-ad-div-id
 ! たまに下部に出るバナーの残骸
 itest.5ch.net##^#float-bnr
+!#endif
 
 !モバイル版5ch「過去ログ」クリック時の余白
 !https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/197
@@ -398,7 +411,12 @@ itest.5ch.net##.js-ad_iframe_wrap
 
 ! 5ch 検索時等
 itest.5ch.net##.ad-adstir
+!#if !env_firefox
+itest.5ch.net###overlay_microad
+!#endif
+!#if env_firefox
 itest.5ch.net##^#overlay_microad
+!#endif
 itest.5ch.net###js-adstir-300x250
 itest.5ch.net###js-adstir-320x50
 itest.5ch.net##.js-cardview_ad-320x180 > iframe
@@ -463,7 +481,12 @@ bbspink.com###top_banner
 !ファミ通
 ||ssl.webtracker.jp/ad/
 s.famitsu.com##.article-body__contents-pr-primary
+!#if !env_firefox
+s.famitsu.com##.banner-header-video-container
+!#endif
+!#if env_firefox
 s.famitsu.com##^.banner-header-video-container
+!#endif
 s.famitsu.com##.l-banner
 
 
@@ -1070,8 +1093,12 @@ togetter.com###ad_list_top
 togetter.com###ad_list_bottom
 togetter.com###fixed_social_footer
 ! Toggetter上部バナー。最近変わったのでまた変わる？
+!#if !env_firefox
+togetter.com##.appdl_header
+!#endif
+!#if env_firefox
 togetter.com##^.appdl_header
-
+!#endif
 !デイリー
 www.daily.co.jp##.adv
 ||jpmarket-d.openx.net^


### PR DESCRIPTION
メンテナンスおつかれさまです。

1. デッドドメインを削除しました（コメント中含め）。
2. ネットワークルール先頭の`www`を削除しました。これはbad tokenであり、あってもなくてもパフォーマンスは変わらないため削除することで僅かながらメモリが節約できます。同様の理由で末尾の`js`なども誤爆の危険がなさそうなものは一部削除しています。非表示については一概に言えないため手を付けていません。またホワイトリストは緩くなる恐れがあるので手を付けていません。
3. HTMLフィルターをサポートしていないプラットフォーム用に`!#if`と通常の非表示ルールを追加しました。
4. 正規表現フィルタは重いので（今回の対象はトークン化されるので、実はそれほどでもないですが）対象を絞り込みました。