### PR TITLE
2 updates

### DIFF
--- a/mochi_filter.txt
+++ b/mochi_filter.txt
@@ -10,7 +10,7 @@
 !共通
 ||google.com/pagead/
 !||clients5.google.com/pagead/drt/dn/
-##div[id^="div-gpt-ad"]
+##[id^="div-gpt-ad"]
 ##.adsbygoogle
 ||ad-api-v01.uliza.jp^
 ||jp-ads.mediaforge.com^
@@ -39,7 +39,7 @@
 ! 共通ルールで問題（エラーやアンチ広告ブロック）の出るサイト
 !https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/174-175
 k05.biz,kakomonn.com,nazolog.com,server-setting.info,z0i.net#@#.adsbygoogle
-www.saitama-np.co.jp#@#div[id^="div-gpt-ad"]
+www.saitama-np.co.jp#@#[id^="div-gpt-ad"]
 
 !画像が見れない
 !https://egg.5ch.net/test/read.cgi/android/1556760647/776

--- a/mochi_filter.txt
+++ b/mochi_filter.txt
@@ -2451,7 +2451,7 @@ www.crank-in.net###bannerin
 ! まとめたやつ
 ! https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/204
 !/^https?:\/\/(apps?|competition|game|mobile|prize|reward|sweeps)[0-9]{4}\.(noname|smmhck|tutonhamon)[-a-z0-9]+\.live/$document,domain=live
-/^https:\/\/[a-z]{4,}\d{3}[a-z]{4,}\.li[fv]e\/(?:\d{10}|[a-z]{8})\/\?/$document,domain=life|live
+/^https:\/\/[a-z]{7,}\.li[fv]e\/[a-z]{8}\/\?/$document,popup,domain=life|live
 !--------
 
 

--- a/tamago_filter.txt
+++ b/tamago_filter.txt
@@ -2158,7 +2158,7 @@ jp.ign.com##.ad-wrapper
 ! まとめたやつ
 ! https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/204
 !/^https?:\/\/(apps?|competition|game|mobile|prize|reward|sweeps)[0-9]{4}\.(noname|smmhck|tutonhamon)[-a-z0-9]+\.live/$document,domain=live
-/^https:\/\/[a-z]{4,}\d{3}[a-z]{4,}\.li[fv]e\/(?:\d{10}|[a-z]{8})\/\?/$document,domain=life|live
+/^https:\/\/[a-z]{7,}\.li[fv]e\/[a-z]{8}\/\?/$document,popup,domain=life|live
 !--------
 
 

--- a/tamago_filter.txt
+++ b/tamago_filter.txt
@@ -17,17 +17,21 @@
 !共通
 ||google.com/pagead/
 !||clients5.google.com/pagead/drt/dn/
-##div[id^="div-gpt-ad"]
-!##^div[id^="div-gpt-ad"]
+!#if adguard
+##[id^="div-gpt-ad"]
 ##.adsbygoogle
-!##^.adsbygoogle
+!#endif
+!#if ext_ublock
+*##[id^="div-gpt-ad"]
+*##.adsbygoogle
+!#endif
 ||ad-api-v01.uliza.jp^
 ||jp-ads.mediaforge.com^
 
 !https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/174-175
 ! 共通ルールで問題（エラーやアンチ広告ブロック）の出るサイト
 k05.biz,kakomonn.com,nazolog.com,server-setting.info,z0i.net#@#.adsbygoogle
-www.saitama-np.co.jp#@#div[id^="div-gpt-ad"]
+saitama-np.co.jp#@#[id^="div-gpt-ad"]
 
 !画像が見れない
 !https://egg.5ch.net/test/read.cgi/android/1556760647/776


### PR DESCRIPTION
1. 詐欺サイト用ルールを最新の傾向に対応
2. https://jbbs.shitaraba.net/bbs/read.cgi/internet/24461/1510462016/373 ですが、モバイルではデフォルトで汎用非表示が無効にされているので意味があると思います。AdGuardとの互換性については目下、ifで対応しました。ついでにEasyListの最近の変更に合わせてdivを取り除きましたが、不都合がありましたら戻してください。まれですがasideやliのケースもあるので無駄にはならないと思います。